### PR TITLE
shared_configs:check should issue a command that can succeed or fail

### DIFF
--- a/lib/capistrano/shared_configs/version.rb
+++ b/lib/capistrano/shared_configs/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module SharedConfigs
-    VERSION = '0.2.1'
+    VERSION = '0.2.2'
   end
 end

--- a/lib/capistrano/tasks/shared_configs.rake
+++ b/lib/capistrano/tasks/shared_configs.rake
@@ -6,11 +6,7 @@ namespace :shared_configs do
   desc 'Checks the project is ready to work with the shared configs directory'
   task :check do
     on roles(:app) do
-      if test("[ -d #{repo_config_path} ]")
-        puts "Found shared configs in #{repo_config_path}."
-      else
-        puts "Unable to locate shared configs in #{repo_config_path}."
-      end
+      execute "ls -ld #{repo_config_path}"
     end
   end
 


### PR DESCRIPTION
Fix #8 

Using this branch, we get better command status details (cf. #8 details):
```
$ bundle exec cap stage shared_configs:check
...
00:00 shared_configs:check
      01 ls -ld /var/sdr2service/sdr-preservation-core/shared/repo_configs
      01 drwxrwxr-x 4 sdr2service sdr2service 4096 Jun 28 15:06 /var/sdr2service/sdr-preservation-core/shared/repo_configs
    ✔ 01 sdr2service@sdr-services-test.stanford.edu 1.121s
      01 drwxr-xr-x 4 sdr2service sdr2service 4096 Jun 28 17:35 /var/sdr2service/sdr-preservation-core/shared/repo_configs
    ✔ 01 sdr2service@sdr-services-test2.stanford.edu 1.592s
...
```